### PR TITLE
#15 use Namer as context to support idempotent render() method call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+.idea/
+
+.mypy_cache/
+.dmypy.json

--- a/fffw/encoding/codec.py
+++ b/fffw/encoding/codec.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Optional, List
+from typing import List
 
 from fffw.graph import base
 from fffw.wrapper import BaseWrapper
@@ -39,8 +39,7 @@ class BaseCodec(BaseWrapper, base.Node, metaclass=abc.ABCMeta):
     def map(self, value: str) -> None:
         self._args['map'] = value
 
-    def render(self, namer: base.Namer, name: Optional[str] = None,
-               partial: bool = False) -> List[str]:
+    def render(self, partial: bool = False) -> List[str]:
         """ codec output node is already rendered in filter graph."""
         return []
 

--- a/fffw/graph/base.py
+++ b/fffw/graph/base.py
@@ -72,20 +72,6 @@ class Renderable(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class NameMixin:
-    """
-    A mixin for single-time object name initialization
-    """
-
-    def __init__(self, name: str):
-        super().__init__()
-        self.__name: str = name
-
-    @property
-    def name(self) -> Optional[str]:
-        return self.__name
-
-
 class Dest(Renderable):
     """
     Audio/video output stream node.

--- a/fffw/graph/base.py
+++ b/fffw/graph/base.py
@@ -104,7 +104,7 @@ class Dest(Renderable):
 
     @property
     def name(self) -> str:
-        return self.name
+        return self.__name
 
     def connect_edge(self, edge: "Edge") -> "Edge":
         """ Connects and edge to output stream.

--- a/fffw/graph/complex.py
+++ b/fffw/graph/complex.py
@@ -59,16 +59,17 @@ class FilterComplex:
         Returns filter_graph description in corresponding ffmpeg param syntax.
         """
         result = []
-        for src in self.video.streams:
-            # noinspection PyProtectedMember
-            if not src._edge:
-                continue
-            result.extend(src.render(self.video_naming, partial=partial))
-        for src in self.audio.streams:
-            # noinspection PyProtectedMember
-            if not src._edge:
-                continue
-            result.extend(src.render(self.audio_naming, partial=partial))
+        with base.Namer():
+            for src in self.video.streams:
+                # noinspection PyProtectedMember
+                if not src._edge:
+                    continue
+                result.extend(src.render(partial=partial))
+            for src in self.audio.streams:
+                # noinspection PyProtectedMember
+                if not src._edge:
+                    continue
+                result.extend(src.render(partial=partial))
 
         # There are no visit checks in recurse graph traversing, so remove
         # duplicates respecting order of appearance.

--- a/fffw/graph/complex.py
+++ b/fffw/graph/complex.py
@@ -21,8 +21,6 @@ class FilterComplex:
         self.audio = audio or sources.Input(kind=base.AUDIO)
         self.__video_outputs: Dict[int, base.Dest] = {}
         self.__audio_outputs: Dict[int, base.Dest] = {}
-        self._video_tmp: Dict[str, int] = collections.Counter()
-        self._audio_tmp: Dict[str, int] = collections.Counter()
 
     def get_video_dest(self, index: int = 0, create: bool = True) -> base.Dest:
         """ Returns video output by index.
@@ -77,25 +75,3 @@ class FilterComplex:
 
     def __str__(self) -> str:
         return self.render()
-
-    def video_naming(self, name: str = 'tmp') -> str:
-        """ Unique video edge identifier generator.
-
-        :param name: prefix used in name generation.
-        :type name: str
-        :rtype: str
-        """
-        res = 'v:%s%s' % (name, self._video_tmp[name])
-        self._video_tmp[name] += 1
-        return res
-
-    def audio_naming(self, name: str = 'tmp') -> str:
-        """ Unique audio edge identifier generator.
-
-        :param name: prefix used in name generation.
-        :type name: str
-        :rtype: str
-        """
-        res = 'a:%s%s' % (name, self._audio_tmp[name])
-        self._audio_tmp[name] += 1
-        return res

--- a/fffw/graph/complex.py
+++ b/fffw/graph/complex.py
@@ -58,6 +58,12 @@ class FilterComplex:
         """
         result = []
         with base.Namer():
+            # Initialize namer context to track unique edge identifiers.
+            # In name generation there is no access to namer, so it is accessed
+            # via Namer singleton's method. Within context it is guaranteed that
+            # same edges will receive same names and different edges will
+            # receive unique names. This includes idempotent results for
+            # subsequent render() calls for outer Namer context.
             for src in self.video.streams:
                 # noinspection PyProtectedMember
                 if not src._edge:

--- a/fffw/graph/sources.py
+++ b/fffw/graph/sources.py
@@ -83,10 +83,13 @@ class Input:
         assert isinstance(other, base.Node)
         input_map = getattr(other, 'map', None)
         for stream in self.streams:
-            if stream.name is None:
-                # skip streams not present in source file
+            try:
+                stream_name = stream.name
+            except RuntimeError:
+                # skip streams not present in input file
                 continue
-            if input_map and input_map == stream.name:
+
+            if input_map and input_map == stream_name:
                 return stream.connect(other)
             if stream.edge is None:
                 return stream.connect(other)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -117,8 +117,8 @@ class FFMPEGTestCase(TestCase):
             '-filter_complex',
             (
                 '[0:v]scale=640x360[v:scale0];'
-                '[v:scale0][v:overlay0]overlay=x=0:y=0[vout0];'
-                '[1:v]scale=1280x720[v:overlay0];'
+                '[v:scale0][v:scale1]overlay=x=0:y=0[vout0];'
+                '[1:v]scale=1280x720[v:scale1];'
                 '[1:a]volume=-20.00[aout0]'),
             '-map', '[vout0]', '-c:v', 'libx264', '-b:v', '700000',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '128000',


### PR DESCRIPTION
closes #15 

* `Namer` context now stores filter counters and caches calls
* `render` method is now more like pure function, it doesn't modify names because they are not stored
* `Namer` context caches names for Nodes, so two subsequent `render` calls will produce same results for each node, even if graph is modified.