### PR TITLE
Make TS deconstructable

### DIFF
--- a/fffw/graph/meta.py
+++ b/fffw/graph/meta.py
@@ -38,12 +38,15 @@ class TS(timedelta):
     Integer values are parsed as milliseconds.
     """
 
-    def __new__(cls, value: Union[int, float, str]) -> "TS":
+    def __new__(cls, value: Union[int, float, str], *args: int) -> "TS":
         """
         :param value: integer duration in milliseconds, float duration in
             seconds or string ffmpeg interval definition (123:59:59.999).
         :returns new timestamp from value.
         """
+        if args:
+            # from deconstruction
+            value = timedelta(value, *args).total_seconds()
         if isinstance(value, int):
             value = value / 1000.0
         elif isinstance(value, str):
@@ -58,6 +61,12 @@ class TS(timedelta):
                 seconds += part
             value = seconds + fractional
         return super().__new__(cls, seconds=value)  # type: ignore
+
+    def __float__(self) -> float:
+        """
+        :returns: duration in seconds.
+        """
+        return self.total_seconds()
 
     def __str__(self) -> str:
         """

--- a/tests/test_meta_data.py
+++ b/tests/test_meta_data.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest import TestCase
 
 from pymediainfo import MediaInfo  # type: ignore
@@ -204,6 +205,14 @@ SAMPLE = '''<?xml version="1.0" encoding="UTF-8"?>
 class MetaDataTestCase(TestCase):
     def setUp(self) -> None:
         self.media_info = MediaInfo(SAMPLE)
+
+    def test_ts_deconstruction(self):
+        ts = meta.TS(3600*24 * 2 + 3600 * 4 + 0.123)
+        self.assertEqual(ts, deepcopy(ts))
+
+    def test_ts_float(self):
+        ts = meta.TS(3600 * 24 * 2 + 3600 * 4 + 0.123)
+        self.assertEqual(float(ts), ts.total_seconds())
 
     def test_parse_streams(self):
         streams = meta.from_media_info(self.media_info)


### PR DESCRIPTION
```
    return copy.deepcopy(obj)
  File "/usr/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.6/copy.py", line 274, in _reconstruct
    y = func(*args)
TypeError: __new__() takes 2 positional arguments but 4 were given
```