### PR TITLE
Refactor stream wrapper

### DIFF
--- a/examples/transcode.py
+++ b/examples/transcode.py
@@ -24,6 +24,6 @@ ff > output
 print(ff.get_cmd())
 
 # run it
-return_code, output = ff.run()
+return_code, output, errors = ff.run()
 if return_code != 0:
-    print(output)
+    print(output, errors)

--- a/examples/wrapper.py
+++ b/examples/wrapper.py
@@ -14,12 +14,9 @@ class MediaInfo(BaseWrapper):
             raise RuntimeError(f"Mediainfo error: {line}")
         return super().handle_stderr(line)
 
-    def get_args(self) -> List[bytes]:
-        return ensure_binary([self.command] + super().get_args())
-
 
 mi = MediaInfo(input_file='input.mp4')
 
-return_code, output = mi.run()
+return_code, output, errors = mi.run()
 if return_code != 0:
-    raise RuntimeError(output)
+    raise RuntimeError(output, errors)

--- a/fffw/encoding/ffmpeg.py
+++ b/fffw/encoding/ffmpeg.py
@@ -163,8 +163,7 @@ class FFMPEG(BaseWrapper):
             fc_args = ['-filter_complex', fc] if fc else []
 
             # Namer context is used to generate unique output stream names
-            return (ensure_binary([self.command]) +
-                    super().get_args() +
+            return (super().get_args() +
                     self.__inputs.get_args() +
                     ensure_binary(fc_args) +
                     self.__outputs.get_args())

--- a/fffw/graph/meta.py
+++ b/fffw/graph/meta.py
@@ -3,11 +3,8 @@ from datetime import timedelta
 from enum import Enum
 from functools import wraps
 from typing import List, Union, Any, Optional, Callable, overload, Tuple, cast
+from fffw.types import Literal
 
-try:
-    from typing import Literal
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore
 
 from pymediainfo import MediaInfo  # type: ignore
 
@@ -132,7 +129,7 @@ class TS(float):
         if isinstance(value, timedelta):
             value = value.total_seconds()
         elif isinstance(value, int):
-            value = value / 1000.0
+            value /= 1000.0
         elif isinstance(value, str):
             if '.' in value:
                 value, rest = value.split('.')

--- a/fffw/types.py
+++ b/fffw/types.py
@@ -1,0 +1,6 @@
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore
+
+__all__ = ['Literal']

--- a/fffw/types.py
+++ b/fffw/types.py
@@ -1,6 +1,6 @@
 try:
-    from typing import Literal, Protocol
+    from typing import Literal
 except ImportError:  # pragma: no cover
-    from typing_extensions import Literal, Protocol  # type: ignore
+    from typing_extensions import Literal  # type: ignore
 
-__all__ = ['Literal', 'Protocol']
+__all__ = ['Literal']

--- a/fffw/types.py
+++ b/fffw/types.py
@@ -1,6 +1,6 @@
 try:
-    from typing import Literal
+    from typing import Literal, Protocol
 except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore
+    from typing_extensions import Literal, Protocol  # type: ignore
 
-__all__ = ['Literal']
+__all__ = ['Literal', 'Protocol']

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -191,7 +191,9 @@ class BaseWrapper(CommandMixin, Params):
             self.logger.debug(line.strip())
         return line
 
-    def run(self, stdin: Union[None, str, TextIO]) -> Tuple[int, str, str]:
+    def run(self,
+            stdin: Union[None, str, TextIO] = None,
+            timeout: Optional[float] = None) -> Tuple[int, str, str]:
         args = self.get_args()
         self.logger.debug(self.get_cmd())
         runner = self.runner(
@@ -199,6 +201,7 @@ class BaseWrapper(CommandMixin, Params):
             stdin=stdin,
             stdout=self.handle_stdout if self.stdout else None,
             stderr=self.handle_stderr if self.stderr else None,
+            timeout=timeout
         )
         return runner()
 

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -195,7 +195,7 @@ class BaseWrapper(CommandMixin, Params):
         runner = Runner(
             self.command, *args,
             stdin=stdin,
-            stdout=self.stdout and self.handle_stdout or None,
-            stderr=self.stderr and self.handle_stderr or None,
+            stdout=self.handle_stdout if self.stdout else None,
+            stderr=self.handle_stderr if self.stderr else None,
         )
         return runner()

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -81,7 +81,9 @@ class Runner:
         while True:
             line = await reader.readline()
             if line:
-                output.write(cb(line.decode()))
+                data = cb(line.decode())
+                if data:
+                    output.write(data)
             else:
                 break
 

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -83,11 +83,15 @@ class BaseWrapper(CommandMixin, Params):
                                 stdout=self.stderr)
 
     def handle_stdout_event(self) -> bool:
+        if not self._proc.stdout:
+            return False
         line = self._proc.stdout.readline()
         self._output.write(self.handle_stdout(ensure_text(line)))
         return bool(line)
 
     def handle_stderr_event(self) -> bool:
+        if not self._proc.stderr:
+            return False
         line = self._proc.stderr.readline()
         self._errors.write(self.handle_stderr(ensure_text(line)))
         return bool(line)

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -213,4 +213,10 @@ class BaseWrapper(CommandMixin, Params):
                stderr: Optional[Callable[[str], str]] = None,
                timeout: Union[int, float, None] = None) -> Runner:
         """ Initializer runner instance."""
-        return self.runner_class(command, *args, stdin, stdout, stderr, timeout)
+        return self.runner_class(
+            command,
+            *args,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            timeout=timeout)

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -13,6 +13,7 @@ from fffw.wrapper.params import Params
 class CommandMixin:
     command: str
     key_prefix: str = '-'
+    key_suffix: str = ' '
     stdin = subprocess.PIPE
     stdout = subprocess.PIPE
     stderr = subprocess.PIPE
@@ -39,10 +40,16 @@ class BaseWrapper(CommandMixin, Params):
     def get_args(self) -> List[Any]:
         args: List[str] = []
         for key, value in self.as_pairs():
+            tokens = []
             if key:
-                args.append(f'{self.key_prefix}{key}')
+                tokens.append(f'{self.key_prefix}{key}')
             if value:
-                args.append(value)
+                tokens.append(value)
+            if tokens:
+                if self.key_suffix == ' ':
+                    args.extend(tokens)
+                else:
+                    args.append(self.key_suffix.join(tokens))
         return args
 
     def get_cmd(self) -> str:

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -63,7 +63,7 @@ class Runner:
         return asyncio.run(self.run())
 
     @staticmethod
-    async def read(reader: asyncio.StreamReader,
+    async def read(reader: Optional[asyncio.StreamReader],
                    cb: Optional[Callable[[str], str]],
                    output: io.StringIO) -> None:
         """
@@ -76,7 +76,7 @@ class Runner:
         :param cb: callback for handling read lines
         :param output: output biffer
         """
-        if cb is None:
+        if cb is None or reader is None:
             return
         while True:
             line = await reader.readline()
@@ -88,7 +88,7 @@ class Runner:
                 break
 
     @staticmethod
-    async def write(writer: asyncio.StreamWriter,
+    async def write(writer: Optional[asyncio.StreamWriter],
                     stream: Optional[TextIO]) -> None:
         """
         Handle write to stdin.
@@ -96,7 +96,7 @@ class Runner:
         :param writer: Process.stdin instance
         :param stream: stream to read lines from
         """
-        if stream is None:
+        if stream is None or writer is None:
             return
         while True:
             line = stream.readline()

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -14,7 +14,7 @@ class CommandMixin:
     command: str
     key_prefix: str = '-'
     key_suffix: str = ' '
-    stdin = subprocess.PIPE
+    stdin = None
     stdout = subprocess.PIPE
     stderr = subprocess.PIPE
 

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -64,7 +64,7 @@ class Runner:
 
     @staticmethod
     async def read(reader: Optional[asyncio.StreamReader],
-                   cb: Optional[Callable[[str], str]],
+                   callback: Optional[Callable[[str], str]],
                    output: io.StringIO) -> None:
         """
         Handles read from stdout/stderr.
@@ -73,15 +73,15 @@ class Runner:
         callback, are written to output buffer.
 
         :param reader: Process.stdout or Process.stderr instance
-        :param cb: callback for handling read lines
+        :param callback: callback for handling read lines
         :param output: output biffer
         """
-        if cb is None or reader is None:
+        if callback is None or reader is None:
             return
         while True:
             line = await reader.readline()
             if line:
-                data = cb(line.decode())
+                data = callback(line.decode())
                 if data:
                     output.write(data)
             else:
@@ -108,7 +108,6 @@ class Runner:
             except (ConnectionResetError, BrokenPipeError):
                 # inspired by Process.communicate
                 return
-        writer.write_eof()
         writer.close()
 
     async def run(self) -> Tuple[int, str, str]:

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -60,7 +60,7 @@ class Runner:
         await self.proc.wait()
 
     def __call__(self) -> Tuple[int, str, str]:
-        return asyncio.run(self.run())
+        return asyncio.get_event_loop().run_until_complete(self.run())
 
     @staticmethod
     async def read(reader: Optional[asyncio.StreamReader],

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -1,15 +1,27 @@
 import io
+import select
 import subprocess
+import time
 from dataclasses import dataclass
 from logging import getLogger
-from typing import Tuple, List, Any, IO, cast, Optional
+from typing import Tuple, List, Any, Optional, cast
 
+from fffw.types import Literal
 from fffw.wrapper.helpers import quote, ensure_binary, ensure_text
 from fffw.wrapper.params import Params
 
+# Optional subprocess PIPE, STDOUT and DEVNULL constants
+Stream = Optional[Literal[-1, -2, -3]]
+
+Streams = Tuple[Stream, Stream, Stream]
+
+
+class CommandMixin:
+    command: str
+
 
 @dataclass
-class BaseWrapper(Params):
+class BaseWrapper(CommandMixin, Params):
     """
     Base class for generating command line arguments from params.
 
@@ -36,23 +48,84 @@ class BaseWrapper(Params):
         return args
 
     def get_cmd(self) -> str:
-        return ' '.join(map(quote, ensure_text(self.get_args())))
+        command_line = [self.command] + ensure_text(self.get_args())
+        return ' '.join(map(quote, command_line))
 
     def handle_stderr(self, line: str) -> str:
         self.logger.debug(line.strip())
-        return line
+        return ''
 
-    def run(self) -> Tuple[int, str]:
-        output = io.StringIO()
+    def handle_stdout(self, line: str) -> str:
+        self.logger.debug(line.strip())
+        return ''
+
+    # noinspection PyMethodMayBeStatic
+    def init_streams(self) -> Streams:
+        stdin = None
+        stdout = cast(Literal[-1], subprocess.PIPE)
+        stderr = cast(Literal[-1], subprocess.PIPE)
+        return stdin, stdout, stderr
+
+    def start_process(self) -> subprocess.Popen:
+        self.logger.info(self.get_cmd())
+        args = [self.command] + self.get_args()
+        stdin, stdout, stderr = self.init_streams()
+        return subprocess.Popen(args,
+                                stdin=stdin,
+                                stderr=stdout,
+                                stdout=stderr)
+
+    def handle_stdout_event(self):
+        line = self._proc.stdout.readline()
+        self._output.write(self.handle_stdout(ensure_text(line)))
+
+    def handle_stderr_event(self):
+        line = self._proc.stderr.readline()
+        self._errors.write(self.handle_stderr(ensure_text(line)))
+
+    # noinspection PyAttributeOutsideInit
+    def run(self, timeout: Optional[float] = None) -> Tuple[int, str, str]:
         self.logger.info(self.get_cmd())
         args = self.get_args()
 
-        with subprocess.Popen(args, stderr=subprocess.PIPE) as proc:
-            while True:
-                stderr = cast(IO[bytes], proc.stderr)
-                line = stderr.readline()
-                if not line:
-                    break
-                output.write(self.handle_stderr(ensure_text(line)))
-        self.logger.info("%s return code is %s", args[0], proc.returncode)
-        return proc.returncode, output.getvalue()
+        self._proc = self.start_process()
+        self._output = io.StringIO()
+        self._errors = io.StringIO()
+        ts = timeout and time.time() + timeout
+        cmd = ensure_text(args[0])
+        try:
+            with self._proc:
+                poll = select.poll()
+                handlers = {}
+                if self._proc.stdout is not None:
+                    fd = self._proc.stdout.fileno()
+                    handlers[fd] = self.handle_stdout_event
+                    poll.register(fd, select.POLLIN)
+                if self._proc.stderr is not None:
+                    fd = self._proc.stderr.fileno()
+                    handlers[fd] = self.handle_stderr_event
+                    poll.register(fd, select.POLLIN)
+                spin = 1024  # ms
+                while self._proc.poll() is None:
+                    for fd, event in poll.poll(spin):
+                        handlers[fd]()
+                        # speedup stdout/stderr reading if present
+                        spin = max(1, spin // 2)
+                    else:
+                        # slow down if no output is read
+                        spin = min(1024, spin * 2)
+                        if ts and ts < time.time():
+                            self.logger.error("Process %s timeouted", cmd)
+                            self._proc.kill()
+
+        except Exception:
+            self._proc.kill()
+            raise
+        finally:
+            return_code = self._proc.returncode
+            output = self._output.getvalue()
+            errors = self._errors.getvalue()
+            self._proc = self._output = self._errors = None
+
+        self.logger.info("%s return code is %s", cmd, return_code)
+        return return_code, output, errors

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -19,7 +19,7 @@ class Runner:
                  stdin: Union[None, str, TextIO] = None,
                  stdout: Optional[Callable[[str], str]] = None,
                  stderr: Optional[Callable[[str], str]] = None,
-                 timeout: Union[int, float, None] = None):
+                 timeout: Union[int, float, None] = None) -> None:
         """
         :param command: executable file name
         :param args: executable arguments
@@ -140,6 +140,8 @@ class CommandMixin:
     key_suffix: str = ' '
     stdout: bool = True
     stderr: bool = True
+    timeout: Optional[float] = None
+    runner_class = Runner
 
 
 @dataclass
@@ -192,10 +194,20 @@ class BaseWrapper(CommandMixin, Params):
     def run(self, stdin: Union[None, str, TextIO]) -> Tuple[int, str, str]:
         args = self.get_args()
         self.logger.debug(self.get_cmd())
-        runner = Runner(
+        runner = self.runner(
             self.command, *args,
             stdin=stdin,
             stdout=self.handle_stdout if self.stdout else None,
             stderr=self.handle_stderr if self.stderr else None,
         )
         return runner()
+
+    def runner(self,
+               command: Union[str, bytes],
+               *args: Any,
+               stdin: Union[None, str, TextIO] = None,
+               stdout: Optional[Callable[[str], str]] = None,
+               stderr: Optional[Callable[[str], str]] = None,
+               timeout: Union[int, float, None] = None) -> Runner:
+        """ Initializer runner instance."""
+        return self.runner_class(command, *args, stdin, stdout, stderr, timeout)

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -68,7 +68,7 @@ class BaseWrapper(CommandMixin, Params):
 
     def start_process(self) -> subprocess.Popen:
         self.logger.info(self.get_cmd())
-        args = [self.command] + self.get_args()
+        args = [ensure_binary(self.command)] + self.get_args()
         return subprocess.Popen(args,
                                 stdin=self.stdin,
                                 stderr=self.stdout,

--- a/fffw/wrapper/base.py
+++ b/fffw/wrapper/base.py
@@ -11,9 +11,11 @@ from fffw.wrapper.params import Params
 from fffw.types import Literal, Protocol
 
 StreamFlag = Optional[Literal[-1, -2, -3]]
+""" Alias for subprocess.PIPE/STDOUT/DEVNULL flags."""
 
 
 class PollProtocol(Protocol):
+    """ Describes select.poll() object."""
     def poll(self, timeout: int) -> List[Tuple[int, int]]: ...
 
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -101,7 +101,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > out1
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-loglevel', 'info',
             '-re',
             '-ss', '123.2',
@@ -130,7 +129,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > self.output
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-filter_complex',
             '[0:v]scale=w=640:h=360[vout0]',
@@ -149,7 +147,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > output
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-filter_complex',
             '[0:v]scale=w=640:h=360[vout0]',
@@ -165,7 +162,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > self.output
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-map', '0:v', '-c:v', 'libx264', '-b:v', '3600000',
             '-map', '0:a', '-c:a', 'aac', '-b:a', '192000',
@@ -191,7 +187,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > self.output
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'logo.png',
             '-i', 'source.mp4',
             '-filter_complex',
@@ -216,7 +211,6 @@ class FFMPEGTestCase(BaseTestCase):
 
         ff > outputs.output_file('/tmp/out.flv', cv0, ca0)
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-filter_complex',
             '[0:a]volume=20.00[aout0]',
@@ -243,7 +237,6 @@ class FFMPEGTestCase(BaseTestCase):
         a > ca1
         ff > out1
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-map', '0:v',
             '-c:v', 'libx264', '-b:v', '3600000',
@@ -274,7 +267,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > outputs.output_file('/tmp/out.flv', cv1, ca1)
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-filter_complex',
             '[0:v]scale=w=640:h=360[vout0]',
@@ -295,7 +287,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff < self.source
         ff > outputs.output_file('/dev/null', format='null')
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'source.mp4',
             '-vn', '-an',
             '-f', 'null',
@@ -350,7 +341,6 @@ class FFMPEGTestCase(BaseTestCase):
         ff > self.output
 
         self.assert_ffmpeg_args(
-            'ffmpeg',
             '-i', 'preroll.mp4',
             '-i', 'source.mp4',
             '-filter_complex',

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -76,7 +76,6 @@ class VectorTestCase(BaseTestCase):
     def test_no_filter_graph(self):
         """ Checks that vector works correctly without filter graph."""
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-map', '0:v', '-c:v', 'libx264',
             '-map', '0:a', '-c:a', 'aac',
@@ -90,7 +89,6 @@ class VectorTestCase(BaseTestCase):
         cursor = self.simd | Volume(30)
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -108,7 +106,6 @@ class VectorTestCase(BaseTestCase):
         cursor = self.simd.audio.connect(Volume(30), mask=[False, True])
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -125,7 +122,6 @@ class VectorTestCase(BaseTestCase):
         cursor = self.simd.audio.connect(Volume(30), mask=[False, False])
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -141,7 +137,6 @@ class VectorTestCase(BaseTestCase):
         cursor = self.simd.audio.connect(Volume, params=[20, 30])
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -159,7 +154,6 @@ class VectorTestCase(BaseTestCase):
         cursor = self.simd.audio.connect(Volume, params=[30, 30])
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -180,7 +174,6 @@ class VectorTestCase(BaseTestCase):
         cursor = cursor | StubFilter(p=0)
         cursor > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-filter_complex',
@@ -212,7 +205,6 @@ class VectorTestCase(BaseTestCase):
 
         v2 > self.simd
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-filter_complex',
             '[0:v]split[v:split0][v:split1];'
@@ -243,7 +235,6 @@ class VectorTestCase(BaseTestCase):
         v.connect(overlay) > self.simd
 
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-i', 'logo.png',
             '-filter_complex',
@@ -272,7 +263,6 @@ class VectorTestCase(BaseTestCase):
         self.simd.video.connect(overlay, mask=[True, False]) > self.simd
 
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-i', 'logo.png',
             '-filter_complex',
@@ -302,7 +292,6 @@ class VectorTestCase(BaseTestCase):
         self.simd.audio.connect(aconcat, mask=[True, False]) > self.simd
 
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-i', 'preroll.mp4',
             '-filter_complex',
@@ -326,7 +315,6 @@ class VectorTestCase(BaseTestCase):
         logo | Scale(120, 120) | overlay > self.simd
 
         self.assert_simd_args(
-            'ffmpeg',
             '-i', 'input.mp4',
             '-i', 'logo.png',
             '-filter_complex',
@@ -353,7 +341,6 @@ class VectorTestCase(BaseTestCase):
         preroll.audio | aconcat > self.simd
 
         self.assert_simd_args(
-            'ffmpeg',
             '-i',
             'input.mp4',
             '-i',


### PR DESCRIPTION
Some command line tools need stdout to interact with, some even accept something in stdin. This PR breaks backward compatibility of BaseWrapper.run and allows to use subprocess stdout, stderr and stdin streams to communicate with child process in non-blocking way.
There are no tests, because child processes and poll kernel interface are better tests manually in related projects. Unittests may be written just to freeze current code flow, but it will not help to find any bugs in this case.