### PR TITLE
Omit params with `init=False` flag while cloning filters

### DIFF
--- a/fffw/encoding/filters.py
+++ b/fffw/encoding/filters.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace, asdict, field
+from dataclasses import dataclass, replace, asdict, field, fields
 from typing import Union, List, cast
 
 from fffw.graph import base
@@ -91,7 +91,8 @@ class Filter(mixins.StreamValidationMixin, base.Node, Params):
 
         Inputs and outputs are not copied.
         """
-        kwargs = asdict(self)
+        skip = [f.name for f in fields(self) if not f.init]
+        kwargs = {k: v for k, v in asdict(self).items() if k not in skip}
         # noinspection PyArgumentList
         return type(self)(**kwargs)  # type: ignore
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, asdict
 from typing import cast, Tuple
 
 from fffw.encoding import *
@@ -373,3 +373,17 @@ class VectorTestCase(BaseTestCase):
             '-c:a', 'libfdk_aac',
             'output2.mp5'
         )
+
+    def test_clone_filter_with_skipped_params(self):
+        """
+        A filter with `init=False` param is cloned correctly.
+        """
+        @dataclass
+        class MyFilter(filters.VideoFilter):
+            my_flag: bool = param(init=False, default=True)
+
+        f = MyFilter()
+
+        cloned = f._clone()
+
+        self.assertTrue(asdict(cloned)['my_flag'])


### PR DESCRIPTION
Closes #63 