### PR TITLE
Use python-3.8 in RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
python-3.9 not yet supported in RTD.

> Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.9