### PR TITLE
Fix check buffering

### DIFF
--- a/fffw/encoding/inputs.py
+++ b/fffw/encoding/inputs.py
@@ -82,7 +82,7 @@ class FFMPEGIndexDescriptor(base.Once):
 
     def __set__(self, instance: base.Obj, value: Any) -> None:
         super().__set__(instance, value)
-        if not isinstance(instance, Input):
+        if not isinstance(instance, Input):  # pragma: no cover
             # We can't seal instance type, but restrict using descriptor only
             # with Input subclasses.
             raise TypeError(instance)

--- a/fffw/encoding/inputs.py
+++ b/fffw/encoding/inputs.py
@@ -80,8 +80,12 @@ class FFMPEGIndexDescriptor(base.Once):
     This index is used to identify streams in filter graph and in metadata.
     """
 
-    def __set__(self, instance: "Input", value: int) -> None:
+    def __set__(self, instance: base.Obj, value: Any) -> None:
         super().__set__(instance, value)
+        if not isinstance(instance, Input):
+            # We can't seal instance type, but restrict using descriptor only
+            # with Input subclasses.
+            raise TypeError(instance)
         instance.connect_streams()
 
 

--- a/fffw/encoding/inputs.py
+++ b/fffw/encoding/inputs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Tuple, cast, Iterable, Union, Any, Type
+from typing import Optional, List, Tuple, cast, Iterable, Union, Any
 
 from fffw.encoding import filters, outputs
 from fffw.graph import base
@@ -80,14 +80,9 @@ class FFMPEGIndexDescriptor(base.Once):
     This index is used to identify streams in filter graph and in metadata.
     """
 
-    def __get__(self, instance: "Input", owner: Type["Input"]) -> int:
-        return super().__get__(instance, owner)
-
     def __set__(self, instance: "Input", value: int) -> None:
         super().__set__(instance, value)
-        identity = f'{instance.input_file}#{value}'
-        for stream in instance.streams:
-            stream.connect_input(identity)
+        instance.connect_streams()
 
 
 @dataclass
@@ -181,6 +176,14 @@ class Input(BaseWrapper):
             if stream.kind == kind:
                 return stream
         raise KeyError(kind)
+
+    def connect_streams(self) -> None:
+        """
+        Sets a unique source identifier for each stream metadata in input.
+        """
+        identity = f'{self.input_file}#{self.index}'
+        for stream in self.streams:
+            stream.connect_input(identity)
 
 
 def input_file(filename: str, *streams: Stream, **kwargs: Any) -> Input:

--- a/fffw/graph/base.py
+++ b/fffw/graph/base.py
@@ -1,5 +1,6 @@
 import abc
 from collections import Counter
+from copy import deepcopy
 from typing import Dict, Any, TypeVar, Type, overload
 from typing import Optional, List, Union
 
@@ -408,7 +409,7 @@ class Source(Traversable, metaclass=abc.ABCMeta):
         """
         self._outputs: List[Edge] = []
         self._kind = kind
-        self._meta = meta
+        self._meta = deepcopy(meta)
 
     def __repr__(self) -> str:
         return f"Source('[{self.name}]')"

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -428,7 +428,6 @@ class FFMPEGTestCase(BaseTestCase):
         Trim buffering could be fixed with multiple source file deconding.
         """
         ff = FFMPEG()
-        # Unlink metadata instances from each other
         v1 = inputs.Stream(VIDEO, self.source.streams[0].meta)
         a1 = inputs.Stream(AUDIO, self.source.streams[1].meta)
         v2 = inputs.Stream(VIDEO, self.source.streams[0].meta)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass
 from unittest import expectedFailure
 
@@ -423,6 +424,39 @@ class FFMPEGTestCase(BaseTestCase):
                 else:
                     self.assertFalse(raises)
 
+    def test_fix_trim_buffering(self):
+        """
+        Trim buffering could be fixed with multiple source file deconding.
+        """
+        ff = FFMPEG()
+        # Unlink metadata instances from each other
+        v1 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
+        a1 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
+        v2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
+        a2 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
+
+        # When an input file is created with a stream, new Origin instance is
+        # created from filename and set to stream meta.
+        in1 = ff < inputs.input_file('input.mp4', v1, a1)
+        in2 = ff < inputs.input_file('input.mp4', v2, a2)
+
+        v = in1.video
+
+        t1 = in1.video | filters.Trim(VIDEO, 2.0, 3.0)
+
+        m = t1.meta
+        p1 = t1 | filters.SetPTS(VIDEO)
+        t2 = in2.video | filters.Trim(VIDEO, 1.0, 2.0)
+        p2 = t2 | filters.SetPTS(VIDEO)
+
+        concat = p1 | filters.Concat(VIDEO)
+        output = outputs.output_file('output.mp4',
+                                     codecs.VideoCodec('libx264'))
+        p2 | concat > output
+
+        ff > output
+        ff.check_buffering()
+
     def test_detect_concat_buffering(self):
         """
         When single source is used for multiple outputs, and one of outputs
@@ -521,7 +555,8 @@ class FFMPEGTestCase(BaseTestCase):
     def test_shortcut_outputs_with_codec(self):
         """ Check ff > output shortcut if codecs list specified."""
         ff = FFMPEG(input=inputs.input_file("input.mp4"))
-        scaled = ff.video | filters.Scale(width=1280, height=720)
+        v = ff.video
+        scaled = v | filters.Scale(width=1280, height=720)
 
         with self.assertRaises(RuntimeError):
             codec = codecs.VideoCodec("libx264")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -401,8 +401,8 @@ class FFMPEGTestCase(BaseTestCase):
             with self.subTest(case):
                 raises, first, second = case
                 ff = FFMPEG()
-                s1 = inputs.Stream(VIDEO, self.source.streams[0].meta)
-                s2 = inputs.Stream(VIDEO, self.source.streams[1].meta)
+                s1 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
+                s2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[1].meta))
 
                 ff < inputs.input_file('input.mp4', s1, s2)
                 split = ff.video | filters.Split(VIDEO)
@@ -435,23 +435,16 @@ class FFMPEGTestCase(BaseTestCase):
         v2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
         a2 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
 
-        # When an input file is created with a stream, new Origin instance is
-        # created from filename and set to stream meta.
         in1 = ff < inputs.input_file('input.mp4', v1, a1)
         in2 = ff < inputs.input_file('input.mp4', v2, a2)
 
-        v = in1.video
+        p1 = in1.video | filters.Trim(VIDEO, 2.0, 3.0) | filters.SetPTS(VIDEO)
+        p2 = in2.video | filters.Trim(VIDEO, 1.0, 2.0) | filters.SetPTS(VIDEO)
 
-        t1 = in1.video | filters.Trim(VIDEO, 2.0, 3.0)
-
-        m = t1.meta
-        p1 = t1 | filters.SetPTS(VIDEO)
-        t2 = in2.video | filters.Trim(VIDEO, 1.0, 2.0)
-        p2 = t2 | filters.SetPTS(VIDEO)
-
-        concat = p1 | filters.Concat(VIDEO)
         output = outputs.output_file('output.mp4',
                                      codecs.VideoCodec('libx264'))
+
+        concat = p1 | filters.Concat(VIDEO)
         p2 | concat > output
 
         ff > output
@@ -473,10 +466,10 @@ class FFMPEGTestCase(BaseTestCase):
             with self.subTest(case):
                 raises, split_pre, split_src = case
                 ff = FFMPEG()
-                v1 = inputs.Stream(VIDEO, self.preroll.streams[0].meta)
-                a1 = inputs.Stream(AUDIO, self.preroll.streams[1].meta)
-                v2 = inputs.Stream(VIDEO, self.source.streams[0].meta)
-                a2 = inputs.Stream(AUDIO, self.source.streams[1].meta)
+                v1 = inputs.Stream(VIDEO, deepcopy(self.preroll.streams[0].meta))
+                a1 = inputs.Stream(AUDIO, deepcopy(self.preroll.streams[1].meta))
+                v2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
+                a2 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
                 ff < inputs.input_file('preroll.mp4', v1, a1)
                 ff < inputs.input_file('source.mp4', v2, a2)
                 vf1 = v1 | filters.Split(VIDEO, output_count=int(split_pre) + 1)
@@ -555,8 +548,7 @@ class FFMPEGTestCase(BaseTestCase):
     def test_shortcut_outputs_with_codec(self):
         """ Check ff > output shortcut if codecs list specified."""
         ff = FFMPEG(input=inputs.input_file("input.mp4"))
-        v = ff.video
-        scaled = v | filters.Scale(width=1280, height=720)
+        scaled = ff.video | filters.Scale(width=1280, height=720)
 
         with self.assertRaises(RuntimeError):
             codec = codecs.VideoCodec("libx264")

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dataclasses import dataclass
 from unittest import expectedFailure
 
@@ -401,8 +400,8 @@ class FFMPEGTestCase(BaseTestCase):
             with self.subTest(case):
                 raises, first, second = case
                 ff = FFMPEG()
-                s1 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
-                s2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[1].meta))
+                s1 = inputs.Stream(VIDEO, self.source.streams[0].meta)
+                s2 = inputs.Stream(VIDEO, self.source.streams[1].meta)
 
                 ff < inputs.input_file('input.mp4', s1, s2)
                 split = ff.video | filters.Split(VIDEO)
@@ -430,10 +429,10 @@ class FFMPEGTestCase(BaseTestCase):
         """
         ff = FFMPEG()
         # Unlink metadata instances from each other
-        v1 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
-        a1 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
-        v2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
-        a2 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
+        v1 = inputs.Stream(VIDEO, self.source.streams[0].meta)
+        a1 = inputs.Stream(AUDIO, self.source.streams[1].meta)
+        v2 = inputs.Stream(VIDEO, self.source.streams[0].meta)
+        a2 = inputs.Stream(AUDIO, self.source.streams[1].meta)
 
         in1 = ff < inputs.input_file('input.mp4', v1, a1)
         in2 = ff < inputs.input_file('input.mp4', v2, a2)
@@ -466,10 +465,10 @@ class FFMPEGTestCase(BaseTestCase):
             with self.subTest(case):
                 raises, split_pre, split_src = case
                 ff = FFMPEG()
-                v1 = inputs.Stream(VIDEO, deepcopy(self.preroll.streams[0].meta))
-                a1 = inputs.Stream(AUDIO, deepcopy(self.preroll.streams[1].meta))
-                v2 = inputs.Stream(VIDEO, deepcopy(self.source.streams[0].meta))
-                a2 = inputs.Stream(AUDIO, deepcopy(self.source.streams[1].meta))
+                v1 = inputs.Stream(VIDEO, self.preroll.streams[0].meta)
+                a1 = inputs.Stream(AUDIO, self.preroll.streams[1].meta)
+                v2 = inputs.Stream(VIDEO, self.source.streams[0].meta)
+                a2 = inputs.Stream(AUDIO, self.source.streams[1].meta)
                 ff < inputs.input_file('preroll.mp4', v1, a1)
                 ff < inputs.input_file('source.mp4', v2, a2)
                 vf1 = v1 | filters.Split(VIDEO, output_count=int(split_pre) + 1)


### PR DESCRIPTION
When `check_buffering()` is called, it ensures that each stream in an input file is read subsequently, without moving back. 
In [timeline editing case](https://fffw.readthedocs.io/en/stable/buffering.html#non-linear-editing) there is a way to prevent buffering by decoding same input file more than once. There is no need to buffer frames because reordered scenes are read from different inputs.
`check_buffering()` call for this workaround does not work, because internally it compares filenames for corresponding concatenated streams.  And even same file is decoded more than once, there is no way to distinguish a stream from first input from a second one.

This PR adds to a filename an internal ffmpeg input index similar to stream identifier in filter graph (See [labeled filtergraph outputs example](http://ffmpeg.org/ffmpeg-all.html#Examples)). This change allows to separate same stream from different files in `check_buffering()` call.