### PR TITLE
Fix -map argument for disabled filters

### DIFF
--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -169,6 +169,24 @@ class FFMPEGTestCase(BaseTestCase):
             'output.mp4'
         )
 
+    def test_bypass_disabled_filter(self):
+        """ Audio stream bypass mode."""
+        ff = self.ffmpeg
+        ff < self.source
+
+        scale = filters.Scale(640, 360)
+        scale.enabled = False
+        ff.video | scale > self.video_codec
+
+        ff > self.output
+
+        self.assert_ffmpeg_args(
+            '-i', 'source.mp4',
+            '-map', '0:v', '-c:v', 'libx264', '-b:v', '3600000',
+            '-map', '0:a', '-c:a', 'aac', '-b:a', '192000',
+            'output.mp4'
+        )
+
     def test_no_audio_if_no_codecs_found(self):
         """ If no audio codecs specified, set -an flag for an output."""
         ff = self.ffmpeg


### PR DESCRIPTION
There is a bug in filter graph naming:
```python
ff = FFMPEG()
ff < input_file('input.mp4')
output = output_file('output.mp4', VideoCodec())
scale = Scale(1280, 720)
ff.video | scale > output
ff > output
print(ff.get_cmd())
# ffmpeg -i input.mp4 -filter_complex "[0:v]scale=w=1280:h=720[vout0]" -map "[vout0]" -an output.mp4
```
If we disable scale filter, input is connected directly to output, so 'map' argument should be '0:v'
Instead we have invalid command line:
```
ffmpeg -i input.mp4 -map "[vout0]" -an output.mp4
```
expected cmd line:
```
ffmpeg -i input.mp4 -map 0:v -an output.mp4
```