### PR TITLE
Shift scenes start while concatenating

### DIFF
--- a/fffw/encoding/filters.py
+++ b/fffw/encoding/filters.py
@@ -367,8 +367,13 @@ class Concat(Filter):
         streams: List[str] = []
         frames: int = 0
         for meta in metadata:
+            for scene in meta.scenes:
+                scenes.append(Scene(
+                    stream=scene.stream,
+                    duration=scene.duration,
+                    start=scene.start + duration
+                ))
             duration += meta.duration
-            scenes.extend(meta.scenes)
             for stream in meta.streams:
                 if not streams or streams[-1] != stream:
                     # Add all streams for each concatenated metadata and remove

--- a/fffw/encoding/filters.py
+++ b/fffw/encoding/filters.py
@@ -269,16 +269,20 @@ class Trim(AutoFilter):
                 streams.append(scene.stream)
 
             # intersect scene with trim interval
-            start = cast(TS, max(self.start, scene.start))
-            end = cast(TS, min(self.end, scene.end))
+            start = cast(TS, max(self.start, scene.position))
+            end = cast(TS, min(self.end, scene.position + scene.duration))
 
             if start < end:
                 # If intersection is not empty, add intersection to resulting
                 # scenes list.
                 # This will allow to detect buffering when multiple scenes are
                 # reordered in same file: input[3:4] + input[1:2]
-                scenes.append(Scene(stream=scene.stream, start=start,
-                                    duration=end - start))
+                offset = start - scene.position
+                scenes.append(Scene(
+                    stream=scene.stream,
+                    start=scene.start + offset,
+                    position=scene.position + offset,
+                    duration=end - start))
 
         kwargs = {
             'start': start,
@@ -371,7 +375,8 @@ class Concat(Filter):
                 scenes.append(Scene(
                     stream=scene.stream,
                     duration=scene.duration,
-                    start=scene.start + duration
+                    start=scene.start,
+                    position=scene.position + duration,
                 ))
             duration += meta.duration
             for stream in meta.streams:

--- a/fffw/graph/meta.py
+++ b/fffw/graph/meta.py
@@ -264,7 +264,9 @@ class Scene:
     duration: TS
     """ Stream duration."""
     start: TS
-    """ First frame/sample timestamp for stream."""
+    """ First frame/sample timestamp in source stream."""
+    position: TS
+    """ Position of scene in current stream."""
 
     @property
     def end(self) -> TS:
@@ -386,6 +388,7 @@ def audio_meta_data(**kwargs: Any) -> AudioMeta:
         stream=stream,
         duration=duration,
         start=start,
+        position=start,
     )
 
     return AudioMeta(
@@ -425,8 +428,9 @@ def video_meta_data(**kwargs: Any) -> VideoMeta:
     start = TS(kwargs.get('start', 0))
     scene = Scene(
         stream=stream,
-        start=start,
         duration=duration,
+        start=start,
+        position=start,
     )
     return VideoMeta(
         scenes=[scene],

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import cast
 from unittest import TestCase
@@ -301,6 +302,33 @@ class FilterGraphTestCase(TestCase):
                          am.duration)
         self.assertEqual(round(am.duration * audio_meta.sampling_rate),
                          am.samples)
+
+    def test_concat_scenes(self):
+        """
+        Concat shifts scenes start/end timestamps.
+        """
+        video_meta = video_meta_data(duration=1000.0,
+                                     frame_count=10000,
+                                     frame_rate=10.0)
+        vs1 = inputs.Stream(VIDEO, meta=video_meta)
+        vs2 = inputs.Stream(VIDEO, meta=video_meta)
+        vs3 = inputs.Stream(VIDEO, meta=video_meta)
+
+        c = Concat(VIDEO, input_count=3)
+        vs1 | c
+        vs2 | c
+        vs3 | c
+        expected = (
+            deepcopy(vs1.meta.scenes) +
+            deepcopy(vs2.meta.scenes) +
+            deepcopy(vs3.meta.scenes)
+        )
+        assert len(expected) == 3
+        current_duration = TS(0)
+        for scene in expected:
+            scene.start += current_duration
+            current_duration += scene.duration
+        self.assertListEqual(c.meta.scenes, expected)
 
     def test_video_trim_metadata(self):
         """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -326,7 +326,7 @@ class FilterGraphTestCase(TestCase):
         assert len(expected) == 3
         current_duration = TS(0)
         for scene in expected:
-            scene.start += current_duration
+            scene.position += current_duration
             current_duration += scene.duration
         self.assertListEqual(c.meta.scenes, expected)
 

--- a/tests/test_meta_data.py
+++ b/tests/test_meta_data.py
@@ -217,7 +217,8 @@ class MetaDataTestCase(TestCase):
         self.assertIsInstance(video, meta.VideoMeta)
         scene = meta.Scene(stream=None,
                            start=meta.TS(0),
-                           duration=meta.TS(6.740))
+                           duration=meta.TS(6.740),
+                           position=meta.TS(0))
         expected = meta.VideoMeta(
             scenes=[scene],
             streams=[],
@@ -237,7 +238,8 @@ class MetaDataTestCase(TestCase):
         self.assertIsInstance(audio, meta.AudioMeta)
         scene = meta.Scene(stream=None,
                            start=meta.TS(0),
-                           duration=meta.TS(6.742))
+                           duration=meta.TS(6.742),
+                           position=meta.TS(0))
         expected = meta.AudioMeta(
             scenes=[scene],
             streams=[],


### PR DESCRIPTION
When Concat combines multiple streams, each scene in metadata should be shifted by duration of previous stream.

Without that scenes list in resulting meta will all have same start time (i.e. `TS(0)`).