### PR TITLE
Always use stream number specifier in map and filter graph definition

### DIFF
--- a/fffw/encoding/inputs.py
+++ b/fffw/encoding/inputs.py
@@ -30,8 +30,6 @@ class Stream(base.Source):
 
     @property
     def name(self) -> str:
-        if self.index == 0:
-            return f'{self.source.index}:{self._kind.value}'
         return f'{self.source.index}:{self._kind.value}:{self.index}'
 
     def split(self, count: int = 1) -> List[filters.Filter]:

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -33,10 +33,10 @@ class InputsTestCase(TestCase):
         il = inputs.InputList((self.i1, self.i2))
         self.assertEqual(il[0].index, 0)
         self.assertEqual(il[1].index, 1)
-        self.assertEqual(self.v1.name, '0:v')
-        self.assertEqual(self.a1.name, '0:a')
-        self.assertEqual(self.v2.name, '1:v')
-        self.assertEqual(self.a2.name, '1:a')
+        self.assertEqual(self.v1.name, '0:v:0')
+        self.assertEqual(self.a1.name, '0:a:0')
+        self.assertEqual(self.v2.name, '1:v:0')
+        self.assertEqual(self.a2.name, '1:a:0')
         self.assertEqual(self.a3.name, '1:a:1')
 
     def test_default_input(self):
@@ -61,7 +61,7 @@ class InputsTestCase(TestCase):
 
         il.append(inputs.Input(streams=(v3,)))
 
-        self.assertEqual(v3.name, '0:v')
+        self.assertEqual(v3.name, '0:v:0')
 
     def test_validate_stream_kind(self):
         """

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -107,7 +107,7 @@ class FFMPEGTestCase(BaseTestCase):
             '-t', '321.2',
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:v]scale=w=640:h=360[vout0];[0:a]asplit[aout0][aout1]',
+            '[0:v:0]scale=w=640:h=360[vout0];[0:a:0]asplit[aout0][aout1]',
 
             '-map', '[vout0]', '-c:v', 'libx264', '-b:v', '3600000',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '192000',
@@ -163,9 +163,9 @@ class FFMPEGTestCase(BaseTestCase):
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:v]scale=w=640:h=360[vout0]',
+            '[0:v:0]scale=w=640:h=360[vout0]',
             '-map', '[vout0]', '-c:v', 'libx264', '-b:v', '3600000',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '192000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '192000',
             'output.mp4'
         )
 
@@ -182,8 +182,8 @@ class FFMPEGTestCase(BaseTestCase):
 
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
-            '-map', '0:v', '-c:v', 'libx264', '-b:v', '3600000',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '192000',
+            '-map', '0:v:0', '-c:v', 'libx264', '-b:v', '3600000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '192000',
             'output.mp4'
         )
 
@@ -199,7 +199,7 @@ class FFMPEGTestCase(BaseTestCase):
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:v]scale=w=640:h=360[vout0]',
+            '[0:v:0]scale=w=640:h=360[vout0]',
             '-map', '[vout0]', '-c:v', 'libx264',
             '-an',
             'out.mp4'
@@ -213,8 +213,8 @@ class FFMPEGTestCase(BaseTestCase):
 
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
-            '-map', '0:v', '-c:v', 'libx264', '-b:v', '3600000',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '192000',
+            '-map', '0:v:0', '-c:v', 'libx264', '-b:v', '3600000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '192000',
             'output.mp4'
         )
 
@@ -240,10 +240,10 @@ class FFMPEGTestCase(BaseTestCase):
             '-i', 'logo.png',
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:v]scale=w=640:h=360[v:scale0];'
+            '[0:v:0]scale=w=640:h=360[v:scale0];'
             '[v:scale0][v:scale1]overlay[vout0];'
-            '[1:v]scale=w=1280:h=720[v:scale1];'
-            '[1:a]volume=-20.00[aout0]',
+            '[1:v:0]scale=w=1280:h=720[v:scale1];'
+            '[1:a:0]volume=-20.00[aout0]',
             '-map', '[vout0]', '-c:v', 'libx264', '-b:v', '3600000',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '192000',
             'output.mp4'
@@ -263,8 +263,8 @@ class FFMPEGTestCase(BaseTestCase):
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:a]volume=20.00[aout0]',
-            '-map', '0:v',
+            '[0:a:0]volume=20.00[aout0]',
+            '-map', '0:v:0',
             '-c:v', 'copy',
             '-map', '[aout0]',
             '-c:a', 'aac', '-b:a', '128000',
@@ -288,14 +288,14 @@ class FFMPEGTestCase(BaseTestCase):
         ff > out1
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
-            '-map', '0:v',
+            '-map', '0:v:0',
             '-c:v', 'libx264', '-b:v', '3600000',
-            '-map', '0:a',
+            '-map', '0:a:0',
             '-c:a', 'aac', '-b:a', '192000',
             'output.mp4',
-            '-map', '0:v',
+            '-map', '0:v:0',
             '-c:v', 'copy',
-            '-map', '0:a',
+            '-map', '0:a:0',
             '-c:a', 'copy',
             '/tmp/out1.flv',
         )
@@ -319,15 +319,15 @@ class FFMPEGTestCase(BaseTestCase):
         self.assert_ffmpeg_args(
             '-i', 'source.mp4',
             '-filter_complex',
-            '[0:v]scale=w=640:h=360[vout0]',
-            '-map', '0:v',
+            '[0:v:0]scale=w=640:h=360[vout0]',
+            '-map', '0:v:0',
             '-c:v', 'copy',
-            '-map', '0:a',
+            '-map', '0:a:0',
             '-c:a', 'copy',
             '/tmp/copy.flv',
             '-map', '[vout0]',
             '-c:v', 'libx264',
-            '-map', '0:a',
+            '-map', '0:a:0',
             '-c:a', 'aac',
             '/tmp/out.flv')
 
@@ -360,9 +360,9 @@ class FFMPEGTestCase(BaseTestCase):
         expected = [
             'ffmpeg',
             '-i', '/tmp/input.mp4',
-            '-map', '0:v',
+            '-map', '0:v:0',
             '-c:v', 'libx264',
-            '-map', '0:a',
+            '-map', '0:a:0',
             '-c:a', 'aac',
             '-f', 'tee',
             '[f=hls:hls_time=2]http://ya.ru/1.m3u8|'
@@ -394,10 +394,10 @@ class FFMPEGTestCase(BaseTestCase):
             '-i', 'preroll.mp4',
             '-i', 'source.mp4',
             '-filter_complex',
-            "[0:v]scale=w=640:h=480[v:scale0];"
+            "[0:v:0]scale=w=640:h=480[v:scale0];"
             "[v:scale0]setsar=1[v:setsar0];"
-            "[v:setsar0][1:v]concat[vout0];"
-            "[0:a][1:a]concat=v=0:a=1:n=2[aout0]",
+            "[v:setsar0][1:v:0]concat[vout0];"
+            "[0:a:0][1:a:0]concat=v=0:a=1:n=2[aout0]",
             '-map', '[vout0]', '-c:v', 'libx264', '-b:v', '3600000',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '192000',
             'output.mp4'

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -212,7 +212,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
 
         expected = ';'.join([
             # overlay logo
-            '[0:v][v:scale0]overlay=x=20:y=20[v:overlay0]',
+            '[0:v:0][v:scale0]overlay=x=20:y=20[v:overlay0]',
             # split video to two streams
             '[v:overlay0]split[v:split0][v:split1]',
             # each video is scaled to own size
@@ -220,10 +220,10 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
             '[v:split1]scale=w=1280:h=720[vout1]',
 
             # split audio to two streams
-            '[0:a]asplit[aout0][aout1]',
+            '[0:a:0]asplit[aout0][aout1]',
 
             # logo scaling
-            '[1:v]scale=w=200:h=50[v:scale0]',
+            '[1:v:0]scale=w=200:h=50[v:scale0]',
         ])
 
         self.assertEqual(expected.replace(';', ';\n'),
@@ -249,13 +249,13 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
             fc, src, dst = fc_factory()
 
             src | Scale(640, 360) | deint_factory() > dst.video
-            self.assertEqual('[0:v]scale=w=640:h=360[vout0]', fc.render())
+            self.assertEqual('[0:v:0]scale=w=640:h=360[vout0]', fc.render())
 
         with self.subTest("intermediate filter disabled"):
             fc, src, dst = fc_factory()
 
             src | deint_factory() | Scale(640, 360) > dst.video
-            self.assertEqual('[0:v]scale=w=640:h=360[vout0]', fc.render())
+            self.assertEqual('[0:v:0]scale=w=640:h=360[vout0]', fc.render())
 
         with self.subTest("all filters disabled"):
             fc, src, dst = fc_factory()
@@ -263,7 +263,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
             tmp = src | deint_factory()
             tmp = tmp | deint_factory()
             tmp | Scale(640, 360) > dst.video
-            self.assertEqual('[0:v]scale=w=640:h=360[vout0]', fc.render())
+            self.assertEqual('[0:v:0]scale=w=640:h=360[vout0]', fc.render())
 
         with self.subTest("two filters disabled"):
             fc, src, dst = fc_factory()
@@ -271,7 +271,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
             tmp = src | Scale(640, 360)
             tmp = tmp | deint_factory()
             tmp | deint_factory() > dst.video
-            self.assertEqual('[0:v]scale=w=640:h=360[vout0]', fc.render())
+            self.assertEqual('[0:v:0]scale=w=640:h=360[vout0]', fc.render())
 
     def test_skip_not_connected_sources(self):
         """ Skip unused sources in filter complex.
@@ -279,7 +279,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
         # passing only video to FilterComplex
         self.source | Scale(640, 360) > self.output
 
-        self.assertEqual('[0:v]scale=w=640:h=360[vout0]', self.fc.render())
+        self.assertEqual('[0:v:0]scale=w=640:h=360[vout0]', self.fc.render())
 
     def test_scale_changes_metadata(self):
         """
@@ -314,7 +314,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
         overlay takes bottom stream metadata
 
         $ ffmpeg -y -i source.mp4 -i logo.mp4 -t 1 \
-         -filter_complex '[0:v][1:v]overlay=x=100:y=100' test.mp4
+         -filter_complex '[0:v:0][1:v]overlay=x=100:y=100' test.mp4
         """
         vs = inputs.Stream(VIDEO, meta=video_meta_data(width=100, height=100))
         self.input_list.append(inputs.input_file('logo.png', vs))
@@ -324,7 +324,7 @@ class FilterGraphTestCase(FilterGraphBaseTestCase):
         vs | overlay
         overlay > self.output
 
-        expected = '[0:v][1:v]overlay=x=1918:y=1078[vout0]'
+        expected = '[0:v:0][1:v:0]overlay=x=1918:y=1078[vout0]'
         self.assertEqual(expected, self.fc.render())
         vm = cast(VideoMeta, self.output.codecs[0].get_meta_data())
         self.assertEqual(vm.width, self.video_metadata.width)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -125,11 +125,11 @@ class VectorTestCase(BaseTestCase):
         """ Checks that vector works correctly without filter graph."""
         self.assert_simd_args(
             '-i', 'input.mp4',
-            '-map', '0:v', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:v:0', '-c:v', 'libx264',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:v:0', '-c:v', 'libx265',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
     def test_filter_graph_pass_through(self):
@@ -139,11 +139,11 @@ class VectorTestCase(BaseTestCase):
 
         self.assert_simd_args(
             '-i', 'input.mp4',
-            '-map', '0:v', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:v:0', '-c:v', 'libx264',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:v:0', '-c:v', 'libx265',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
     def test_single_quality_copy_pass_through(self):
@@ -160,12 +160,12 @@ class VectorTestCase(BaseTestCase):
         self.assert_simd_args(
             '-i', 'input.mp4',
             '-filter_complex',
-            '[0:v]scale=w=1920:h=1080[vout0]',
+            '[0:v:0]scale=w=1920:h=1080[vout0]',
             '-map', '[vout0]', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'copy',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:v:0', '-c:v', 'copy',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
     def test_same_filter_for_all_streams(self):
@@ -176,12 +176,12 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]volume=30.00[a:volume0];'
+            '[0:a:0]volume=30.00[a:volume0];'
             '[a:volume0]asplit[aout0][aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -193,12 +193,12 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]asplit[a:asplit0][aout0];'
+            '[0:a:0]asplit[a:asplit0][aout0];'
             '[a:asplit0]volume=30.00[aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -209,11 +209,11 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]asplit[aout0][aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '[0:a:0]asplit[aout0][aout1]',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -224,13 +224,13 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]asplit[a:asplit0][a:asplit1];'
+            '[0:a:0]asplit[a:asplit0][a:asplit1];'
             '[a:asplit0]volume=20.00[aout0];'
             '[a:asplit1]volume=30.00[aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -241,12 +241,12 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]volume=30.00[a:volume0];'
+            '[0:a:0]volume=30.00[a:volume0];'
             '[a:volume0]asplit[aout0][aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -261,15 +261,15 @@ class VectorTestCase(BaseTestCase):
             '-i',
             'input.mp4',
             '-filter_complex',
-            '[0:a]asplit[a:asplit0][a:asplit1];'
+            '[0:a:0]asplit[a:asplit0][a:asplit1];'
             '[a:asplit0]volume=20.00[a:volume0];'
             '[a:volume0]stub[aout0];'
             '[a:asplit1]volume=30.00[a:volume1];'
             '[a:volume1]stub[aout1]',
-            '-map', '0:v', '-c:v', 'libx264',
+            '-map', '0:v:0', '-c:v', 'libx264',
             '-map', '[aout0]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
-            '-map', '0:v', '-c:v', 'libx265',
+            '-map', '0:v:0', '-c:v', 'libx265',
             '-map', '[aout1]', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
@@ -291,7 +291,7 @@ class VectorTestCase(BaseTestCase):
         self.assert_simd_args(
             '-i', 'input.mp4',
             '-filter_complex',
-            '[0:v]split[v:split0][v:split1];'
+            '[0:v:0]split[v:split0][v:split1];'
             '[v:split0]some[v:some0];'
             '[v:split1]another[v:another0];'
             '[v:some0]split[v:split2][v:split3];'
@@ -301,10 +301,10 @@ class VectorTestCase(BaseTestCase):
             '[v:split4][v:scale0]overlay[vout0];'
             '[v:split5][v:scale1]overlay[vout1]',
             '-map', '[vout0]', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
             '-map', '[vout1]', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5')
 
     def test_clone_streams(self):
@@ -322,17 +322,17 @@ class VectorTestCase(BaseTestCase):
             '-i', 'input.mp4',
             '-i', 'logo.png',
             '-filter_complex',
-            '[0:v]split[v:split0][v:split1];'
-            '[1:v]split[v:split2][v:split3];'
+            '[0:v:0]split[v:split0][v:split1];'
+            '[1:v:0]split[v:split2][v:split3];'
             '[v:split0]scale=w=1280:h=720[v:scale0];'
             '[v:split1]scale=w=640:h=360[v:scale1];'
             '[v:split2][v:scale0]overlay[vout0];'
             '[v:split3][v:scale1]overlay[vout1]',
             '-map', '[vout0]', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
             '-map', '[vout1]', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5'
         )
 
@@ -350,13 +350,13 @@ class VectorTestCase(BaseTestCase):
             '-i', 'input.mp4',
             '-i', 'logo.png',
             '-filter_complex',
-            '[0:v]split[v:split0][vout0];'
-            '[1:v][v:split0]overlay[vout1]',
+            '[0:v:0]split[v:split0][vout0];'
+            '[1:v:0][v:split0]overlay[vout1]',
             '-map', '[vout1]', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
             '-map', '[vout0]', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5'
         )
 
@@ -379,10 +379,10 @@ class VectorTestCase(BaseTestCase):
             '-i', 'input.mp4',
             '-i', 'preroll.mp4',
             '-filter_complex',
-            '[0:v]split[v:split0][vout0];'
-            '[0:a]asplit[a:asplit0][aout0];'
-            '[1:v][v:split0]concat[vout1];'
-            '[1:a][a:asplit0]concat=v=0:a=1:n=2[aout1]',
+            '[0:v:0]split[v:split0][vout0];'
+            '[0:a:0]asplit[a:asplit0][aout0];'
+            '[1:v:0][v:split0]concat[vout1];'
+            '[1:a:0][a:asplit0]concat=v=0:a=1:n=2[aout1]',
             '-map', '[vout1]', '-c:v', 'libx264',
             '-map', '[aout1]', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
@@ -404,13 +404,13 @@ class VectorTestCase(BaseTestCase):
             '-i', 'logo.png',
             '-filter_complex',
             '[v:overlay0]split[vout0][vout1];'
-            '[1:v]scale=w=120:h=120[v:scale0];'
-            '[0:v][v:scale0]overlay[v:overlay0]',
+            '[1:v:0]scale=w=120:h=120[v:scale0];'
+            '[0:v:0][v:scale0]overlay[v:overlay0]',
             '-map', '[vout0]', '-c:v', 'libx264',
-            '-map', '0:a', '-c:a', 'aac', '-b:a', '64000',
+            '-map', '0:a:0', '-c:a', 'aac', '-b:a', '64000',
             'output1.mp4',
             '-map', '[vout1]', '-c:v', 'libx265',
-            '-map', '0:a', '-c:a', 'libfdk_aac',
+            '-map', '0:a:0', '-c:a', 'libfdk_aac',
             'output2.mp5'
         )
 
@@ -432,10 +432,10 @@ class VectorTestCase(BaseTestCase):
             'preroll.mp4',
             '-filter_complex',
             '[v:scale0]split[vout0][vout1];'
-            '[1:a][1:a]concat=v=0:a=1:n=2[a:concat0];'
+            '[1:a:0][1:a:0]concat=v=0:a=1:n=2[a:concat0];'
             '[a:concat0]asplit[aout0][aout1];'
             '[v:concat0]scale=w=1820:h=720[v:scale0];'
-            '[1:v][1:v]concat[v:concat0]',
+            '[1:v:0][1:v:0]concat[v:concat0]',
             '-map', '[vout0]',
             '-c:v', 'libx264',
             '-map', '[aout0]',


### PR DESCRIPTION
When passing `-map 0:a` to an audio codec, ffmpeg passes all audio streams from first file to output, and that's not what is expected in internal graph. 

BREAKING CHANGE:

Now instead of all audio streams, connecting source stream to a codec directly will produce only first audio stream, instead of all of them. 